### PR TITLE
Add height to images to respect defined hotspots

### DIFF
--- a/src/FacebookSharePreview.tsx
+++ b/src/FacebookSharePreview.tsx
@@ -12,7 +12,7 @@ const FacebookSharePreview: React.FC<BasePreviewProps> = ({
   siteUrl
 }) => {
   const ogImageUrl: string | undefined = ogImage
-    ? urlFor(ogImage).width(500).url() || undefined
+    ? urlFor(ogImage).size(1200, 630).url() || undefined
     : undefined
   return (
     <section

--- a/src/GooglePreview.tsx
+++ b/src/GooglePreview.tsx
@@ -38,7 +38,7 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
   const url = siteUrl + (slug || '')
 
   const ogImageUrl: string | undefined = ogImage
-    ? urlFor(ogImage).width(105).url() || undefined
+    ? urlFor(ogImage).size(104, 104).url() || undefined
     : undefined
 
   return (

--- a/src/LinkedinSharePreview.tsx
+++ b/src/LinkedinSharePreview.tsx
@@ -11,7 +11,7 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> =({
   ogImage,
 }) => {
   const ogImageUrl: string | undefined = ogImage
-    ? urlFor(ogImage).width(1200).url() || undefined
+    ? urlFor(ogImage).size(1200, 630).url() || undefined
     : undefined
   return (
     <section className="share-item" style={{ background: '#f5f5f5' }}>

--- a/src/TwitterSharePreview.tsx
+++ b/src/TwitterSharePreview.tsx
@@ -11,7 +11,7 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
   siteUrl,
 }) => {
   const ogImageUrl: string | undefined = ogImage
-    ? urlFor(ogImage).width(560).url() || undefined
+    ? urlFor(ogImage).size(1200, 600).url() || undefined
     : undefined
   return (
     <section


### PR DESCRIPTION
Hey! @hdoro 
Thanks for this awesome plugin 😃 I also had a similar one that I would copy over from project to project. Glad to see that somebody took the time to publish his version 😄

About my PR:
I noticed that the hotspots defined in the Studio were not taken into account. The reason is that no heights were set for the images.

Notes:
- from my short research, Twitter prefers the aspect ratio 2:1 (Open Graph is 1.91:1), that is why I set 1600x600 for Twitter and not 1600x630.
- checking in my browser, the Google mobile image preview sizes are 104x104