### PR TITLE
Clip long descriptions in mobile google preview

### DIFF
--- a/src/GooglePreview.tsx
+++ b/src/GooglePreview.tsx
@@ -50,7 +50,11 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
         </div>
         <h3>{title}</h3>
         <div className={s.contentMobile}>
-          <div>{description}</div>
+          <div>
+            {description && description.length > 135
+              ? description.slice(0, 135) + ' ...'
+              : description}
+          </div>
           {ogImageUrl && <img src={ogImageUrl} />}
         </div>
       </div>


### PR DESCRIPTION
The Mobile Google Preview component wasn't clipping longer descriptions like the other components, so I copied the functionality from the Desktop preview here!

Example of the problem:
![image](https://user-images.githubusercontent.com/5818258/110705661-b7134a80-81c4-11eb-8d05-a9f11ddb2453.png)
