### PR TITLE
Allow absolute url for ogimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This plugin tries to mimic [Sanity's `preview` behavior on list views](https://w
   description: doc.description || doc.metaDescription || doc.seoDescription,
   siteUrl: 'https://example.com',
   ogImage: doc.openGraphImage || doc.ogImage || doc.image,
+  ogImageAbsoluteUrl: 'https://example.com/ogImage.jpeg',
   slug: doc.slug?.current || doc.relativePath?.current,
 }
 ```
@@ -102,6 +103,7 @@ interface PreparedPreview {
       _type: 'reference'
     }
   }
+  ogImageAbsoluteUrl?: string
   // Used by Google preview to render the full URL
   // Note that this is a string, not an object (slug { current: string })
   slug?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-social-preview",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/FacebookSharePreview.tsx
+++ b/src/FacebookSharePreview.tsx
@@ -12,9 +12,20 @@ const FacebookSharePreview: React.FC<BasePreviewProps> = ({
   ogImageAbsoluteUrl,
   siteUrl,
 }) => {
+  let absoluteImageUrl: string | undefined
+
+  if (ogImageAbsoluteUrl) {
+    absoluteImageUrl =
+      ogImageAbsoluteUrl.startsWith('https://') ||
+      ogImageAbsoluteUrl.startsWith('http://') ||
+      ogImageAbsoluteUrl.startsWith('//')
+        ? ogImageAbsoluteUrl
+        : undefined
+  }
+
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 630).url() || undefined
-    : ogImageAbsoluteUrl || undefined
+    : absoluteImageUrl || undefined
   return (
     <section
       className="share-item"

--- a/src/FacebookSharePreview.tsx
+++ b/src/FacebookSharePreview.tsx
@@ -9,7 +9,6 @@ const FacebookSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
-  ogImageAbsoluteUrl,
   siteUrl,
 }) => {
   let absoluteImageUrl: string | undefined

--- a/src/FacebookSharePreview.tsx
+++ b/src/FacebookSharePreview.tsx
@@ -9,11 +9,12 @@ const FacebookSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
+  ogImageAbsoluteUrl,
   siteUrl,
 }) => {
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 630).url() || undefined
-    : undefined
+    : ogImageAbsoluteUrl || undefined
   return (
     <section
       className="share-item"

--- a/src/GooglePreview.tsx
+++ b/src/GooglePreview.tsx
@@ -20,7 +20,7 @@ export const GoogleDesktop: React.FC<BasePreviewProps> = ({
         <div className={s.metaDesktop}>{url}</div>
         <p>
           {description && description.length > 135
-            ? `${description.slice(0, 135)} ...`
+            ? description.slice(0, 135) + ' ...'
             : description}
         </p>
       </div>
@@ -32,11 +32,11 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
-  ogImageAbsoluteUrl,
   siteUrl,
   slug,
 }) => {
   const url = siteUrl + (slug || '')
+
   let absoluteImageUrl: string | undefined
 
   if (ogImageAbsoluteUrl) {
@@ -55,18 +55,15 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
   return (
     <section className="share-item">
       <h2>Mobile Google result</h2>
-      <div className={`${s.wrapper} ${s.wrapperMobile}`}>
+      <div className={s.wrapper + ' ' + s.wrapperMobile}>
         <div className={s.metaMobile}>
-          <div>
-            <img src={`//logo.clearbit.com/${url}`} alt="Logo for website" />
-          </div>{' '}
-          {url}
+          <div /> {url}
         </div>
         <h3>{title}</h3>
         <div className={s.contentMobile}>
           <div>
             {description && description.length > 135
-              ? `${description.slice(0, 135)} ...`
+              ? description.slice(0, 135) + ' ...'
               : description}
           </div>
           {ogImageUrl && <img src={ogImageUrl} />}

--- a/src/GooglePreview.tsx
+++ b/src/GooglePreview.tsx
@@ -20,7 +20,7 @@ export const GoogleDesktop: React.FC<BasePreviewProps> = ({
         <div className={s.metaDesktop}>{url}</div>
         <p>
           {description && description.length > 135
-            ? description.slice(0, 135) + ' ...'
+            ? `${description.slice(0, 135)} ...`
             : description}
         </p>
       </div>
@@ -37,23 +37,36 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
   slug,
 }) => {
   const url = siteUrl + (slug || '')
+  let absoluteImageUrl: string | undefined
+
+  if (ogImageAbsoluteUrl) {
+    absoluteImageUrl =
+      ogImageAbsoluteUrl.startsWith('https://') ||
+      ogImageAbsoluteUrl.startsWith('http://') ||
+      ogImageAbsoluteUrl.startsWith('//')
+        ? ogImageAbsoluteUrl
+        : undefined
+  }
 
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(104, 104).url() || undefined
-    : ogImageAbsoluteUrl || undefined
+    : absoluteImageUrl || undefined
 
   return (
     <section className="share-item">
       <h2>Mobile Google result</h2>
-      <div className={s.wrapper + ' ' + s.wrapperMobile}>
+      <div className={`${s.wrapper} ${s.wrapperMobile}`}>
         <div className={s.metaMobile}>
-          <div /> {url}
+          <div>
+            <img src={`//logo.clearbit.com/${url}`} alt="Logo for website" />
+          </div>{' '}
+          {url}
         </div>
         <h3>{title}</h3>
         <div className={s.contentMobile}>
           <div>
             {description && description.length > 135
-              ? description.slice(0, 135) + ' ...'
+              ? `${description.slice(0, 135)} ...`
               : description}
           </div>
           {ogImageUrl && <img src={ogImageUrl} />}

--- a/src/GooglePreview.tsx
+++ b/src/GooglePreview.tsx
@@ -32,6 +32,7 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
+  ogImageAbsoluteUrl,
   siteUrl,
   slug,
 }) => {
@@ -39,7 +40,7 @@ export const GoogleMobile: React.FC<BasePreviewProps> = ({
 
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(104, 104).url() || undefined
-    : undefined
+    : ogImageAbsoluteUrl || undefined
 
   return (
     <section className="share-item">

--- a/src/LinkedinSharePreview.tsx
+++ b/src/LinkedinSharePreview.tsx
@@ -11,9 +11,20 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> = ({
   ogImage,
   ogImageAbsoluteUrl,
 }) => {
+  let absoluteImageUrl: string | undefined
+
+  if (ogImageAbsoluteUrl) {
+    absoluteImageUrl =
+      ogImageAbsoluteUrl.startsWith('https://') ||
+      ogImageAbsoluteUrl.startsWith('http://') ||
+      ogImageAbsoluteUrl.startsWith('//')
+        ? ogImageAbsoluteUrl
+        : undefined
+  }
+
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 630).url() || undefined
-    : ogImageAbsoluteUrl || undefined
+    : absoluteImageUrl || undefined
   return (
     <section className="share-item" style={{ background: '#f5f5f5' }}>
       <h2>LinkedIn sharing</h2>

--- a/src/LinkedinSharePreview.tsx
+++ b/src/LinkedinSharePreview.tsx
@@ -9,10 +9,11 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
+  ogImageAbsoluteUrl,
 }) => {
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 630).url() || undefined
-    : undefined
+    : ogImageAbsoluteUrl || undefined
   return (
     <section className="share-item" style={{ background: '#f5f5f5' }}>
       <h2>LinkedIn sharing</h2>

--- a/src/LinkedinSharePreview.tsx
+++ b/src/LinkedinSharePreview.tsx
@@ -9,7 +9,6 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
-  ogImageAbsoluteUrl,
 }) => {
   let absoluteImageUrl: string | undefined
 
@@ -25,6 +24,7 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> = ({
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 630).url() || undefined
     : absoluteImageUrl || undefined
+    
   return (
     <section className="share-item" style={{ background: '#f5f5f5' }}>
       <h2>LinkedIn sharing</h2>

--- a/src/TwitterSharePreview.tsx
+++ b/src/TwitterSharePreview.tsx
@@ -8,7 +8,6 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
-  ogImageAbsoluteUrl,
   siteUrl,
 }) => {
   let absoluteImageUrl: string | undefined = undefined
@@ -25,6 +24,7 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 600).url() || undefined
     : absoluteImageUrl || undefined
+    
   return (
     <section
       className="share-item"

--- a/src/TwitterSharePreview.tsx
+++ b/src/TwitterSharePreview.tsx
@@ -8,11 +8,12 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
   title,
   description,
   ogImage,
+  ogImageAbsoluteUrl,
   siteUrl,
 }) => {
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 600).url() || undefined
-    : undefined
+    : ogImageAbsoluteUrl || undefined
   return (
     <section
       className="share-item"

--- a/src/TwitterSharePreview.tsx
+++ b/src/TwitterSharePreview.tsx
@@ -11,9 +11,20 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
   ogImageAbsoluteUrl,
   siteUrl,
 }) => {
+  let absoluteImageUrl: string | undefined = undefined
+
+  if (ogImageAbsoluteUrl) {
+    absoluteImageUrl =
+      ogImageAbsoluteUrl.startsWith('https://') ||
+      ogImageAbsoluteUrl.startsWith('http://') ||
+      ogImageAbsoluteUrl.startsWith('//')
+        ? ogImageAbsoluteUrl
+        : undefined
+  }
+
   const ogImageUrl: string | undefined = ogImage
     ? urlFor(ogImage).size(1200, 600).url() || undefined
-    : ogImageAbsoluteUrl || undefined
+    : absoluteImageUrl || undefined
   return (
     <section
       className="share-item"

--- a/src/previewTypes.d.ts
+++ b/src/previewTypes.d.ts
@@ -47,6 +47,7 @@ export interface BasePreviewProps {
   title: string
   description?: string
   ogImage?: SanityImage
+  ogImageAbsoluteUrl?: string
   siteUrl: string
   slug?: string
 }


### PR DESCRIPTION
Allow users to optionally set an absolute url for the OpenGraph image. Handy for cases when OG images might be generated using third-party services (e.g. Cloudinary) or serverless functions.

Created a new variable that can be passed along in the options. If a document image is present, then that image will be used first regardless of if an absolute URL is provided.