### PR TITLE
Fixing image placeholder URL of the author/person

### DIFF
--- a/src/FacebookSharePreview.tsx
+++ b/src/FacebookSharePreview.tsx
@@ -22,7 +22,7 @@ const FacebookSharePreview: React.FC<BasePreviewProps> = ({
       <h2>Facebook sharing</h2>
       <div className={s.wrapper}>
         <div className={s.header}>
-          <img src="https://via.placeholder.com/40/40" aria-hidden />
+          <img src="https://via.placeholder.com/40x40" aria-hidden />
           <div>Person</div>
           <span>
             1h <GlobeIcon />

--- a/src/LinkedinSharePreview.tsx
+++ b/src/LinkedinSharePreview.tsx
@@ -18,7 +18,7 @@ const LinkedinSharePreview: React.FC<BasePreviewProps> = ({
       <h2>LinkedIn sharing</h2>
       <div className={s.wrapper}>
         <div className={s.profile}>
-          <img src="https://via.placeholder.com/48/48" aria-hidden />
+          <img src="https://via.placeholder.com/48x48" aria-hidden />
           <div>
             Person <span>• 1st</span>
           </div>

--- a/src/TwitterSharePreview.tsx
+++ b/src/TwitterSharePreview.tsx
@@ -22,7 +22,7 @@ const TwitterSharePreview: React.FC<BasePreviewProps> = ({
       <div className={s.wrapper}>
         <div className={s.header}>
           <div className={s.profile}>
-            <img src="https://via.placeholder.com/48/48" aria-hidden />
+            <img src="https://via.placeholder.com/48x48" aria-hidden />
             <div>Person</div>
             <span>@person</span>
           </div>


### PR DESCRIPTION
Hey @hdoro, thanks for making this plugin.

This fixes the image placeholder URL of the author/person. See https://betterplaceholder.com/

Example of the issue:
![image](https://user-images.githubusercontent.com/25883086/215028528-e39bd4a8-b147-4732-8957-b74a98786e82.png)
