### PR TITLE
Fix broken dark mode styles in `Google.tsx`

### DIFF
--- a/src/networks/Google.tsx
+++ b/src/networks/Google.tsx
@@ -8,45 +8,92 @@ import { getDomainName, truncate } from '../utils'
 const DesktopWrapper = styled.div`
   line-height: 1.3;
   font-family: arial, sans-serif;
-  max-width: 773px;
+  max-width: 600px;
+  padding: 20px;
+  box-sizing: content-box;
+  border-radius: 8px;
 
   .header {
     display: flex;
     align-items: center;
-    padding: 1px 0 2px 0;
-    font-size: 14px;
-    color: #202124;
-    height: 20.539px; }
+    font-size: 12px;
+  }
 
-    .header > span {
-      padding-right: 12px;
-    }
+  .dots {
+    margin-left: 12px;
+    transform: rotate(90deg);
+  }
 
-    .dots {
-      transform: rotate(90deg);
-      padding-top: 5px;
-    }
-
-    .dots > svg {
-      width: 16px;
-      height: 16px;
-    }
+  .dots > svg {
+    width: 12px;
+    height: 12px;
   }
 
   > h3 {
-    color: #1a0dab;
+    margin: 5px 0 0;
     font-size: 20px;
     line-height: 1.3;
     font-weight: normal;
-    margin: 5px 0 3px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+
+    :hover {
+      text-decoration: underline;
+    }
   }
 
-  > p {
-    color: #4d5156;
+  > p,
+  > span {
+    margin: 0;
     font-size: 14px;
     line-height: 1.58;
     word-wrap: break-word;
-    margin: 0;
+    display: inline-block;
+  }
+
+  [data-scheme='light'] & {
+    background-color: #fff;
+
+    .header {
+      color: #4d5156;
+
+      .dots > svg {
+        fill: #4d5156;
+      }
+    }
+
+    > h3 {
+      color: #1a0dab;
+    }
+    > span {
+      color: #70757a;
+    }
+    > p {
+      color: #4d5156;
+    }
+  }
+
+  [data-scheme='dark'] & {
+    background-color: #202124;
+
+    .header {
+      color: #bdc1c6;
+
+      .dots > svg {
+        fill: #9aa0a6;
+      }
+    }
+
+    > h3 {
+      color: #8ab4f8;
+    }
+    > span {
+      color: #9aa0a6;
+    }
+    > p {
+      color: #bdc1c6;
+    }
   }
 `
 
@@ -61,7 +108,7 @@ export function GoogleDesktop({ title, description, url }: BasePreviewProps) {
           </div>
         </div>
         <h3>{title}</h3>
-        {/* @TODO: add optional date before description */}
+        {/* {date && <span>Mar 9, 2021&nbsp;—&nbsp;</span>} */}
         {description && <p>{truncate(description, 135)}</p>}
       </DesktopWrapper>
     </ShareItem>

--- a/src/networks/Google.tsx
+++ b/src/networks/Google.tsx
@@ -108,6 +108,7 @@ export function GoogleDesktop({ title, description, url }: BasePreviewProps) {
           </div>
         </div>
         <h3>{title}</h3>
+        {/* @TODO: add optional date before description */}
         {/* {date && <span>Mar 9, 2021&nbsp;—&nbsp;</span>} */}
         {description && <p>{truncate(description, 135)}</p>}
       </DesktopWrapper>


### PR DESCRIPTION
This PR fixes the broken styles for the Google preview when using Sanity in dark mode. It also updates the light mode styles to better match what Google is currently using.

I also added the markup and styles to show a date before the `description` as suggested in the TODO comment. Enabling this change will require to update the types for `BasePreviewProps` to also accept a `date` prop. 

I can do it myself if you want me to. Left it out the PR for now since I wanted this to be focused on fixing dark mode styles. 

I'd also like to improve the styles for other _networks_ in the future if that's okay with you.

| before | after |
|--------|------|
| ![prduction homePage social-previews](https://github.com/hdoro/sanity-plugin-social-preview/assets/1107521/4ce0b8ac-65cf-4050-9a40-940159b7620f) | ![localhost homePage social-previews](https://github.com/hdoro/sanity-plugin-social-preview/assets/1107521/3fb6f5cd-f61a-48c9-8ec8-213394822266) |



